### PR TITLE
Remove VxWorks from list of supported targets

### DIFF
--- a/Source/Custom Device/Custom Device Communication Bus Template.xml
+++ b/Source/Custom Device/Custom Device Communication Bus Template.xml
@@ -35,14 +35,6 @@
         <RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\Communication Bus Template\Communication Bus Template Engine Pharlap.llb\RT Driver VI.vi</RealTimeSystemDestination>
       </Source>
       <Source>
-        <SupportedTarget>VxWorks</SupportedTarget>
-        <Source>
-          <Type>To Common Doc Dir</Type>
-          <Path>Custom Devices\Communication Bus Template\VxWorks\Communication Bus Template Engine VxWorks.llb\RT Driver VI.vi</Path>
-        </Source>
-        <RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\Communication Bus Template\Communication Bus Template Engine VxWorks.llb\RT Driver VI.vi</RealTimeSystemDestination>
-      </Source>
-      <Source>
         <SupportedTarget>Linux_32_ARM</SupportedTarget>
         <Source>
           <Type>To Common Doc Dir</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Removes VxWorks from the list of supported targets.

### Why should this Pull Request be merged?

We removed the build spec for VxWorks.

### What testing has been done?

Confirmed VeriStand can still add the custom device properly.
