### PR TITLE
Update `xnet` codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add names of code owners for this repo
-* @niphilj @buckd
+* @niphilj @rtzoeller @douglasnorman


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Replace @buckd with @rtzoeller and @douglasnorman as codeowners for `xnet`.

### Why should this Pull Request be merged?

This aligns the owners with the individuals actively working on the branch.

### What testing has been done?

None.
