### PR TITLE
Add custom device without National Instruments menu

### DIFF
--- a/Source/Custom Device/Custom Device Communication Bus Template.xml
+++ b/Source/Custom Device/Custom Device Communication Bus Template.xml
@@ -2,8 +2,8 @@
 <CustomDevice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Custom Device.xsd">
 	<XSDVersion Major="2010" Minor="0" Fix="0" Build="0" />
 	<AddMenu>
-		<eng>National Instruments::Communication Bus Template</eng>
-		<loc>National Instruments::Communication Bus Template</loc>
+		<eng>Communication Bus Template</eng>
+		<loc>Communication Bus Template</loc>
 	</AddMenu>
 	<Version>1.0.0</Version>
 	<Type>Inline HW Interface</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds the custom device entry to the top-level **Add** menu instead of parenting under `National Instruments`.

### Why should this Pull Request be merged?

Fixes #106 

### What testing has been done?

None
