### PR TITLE
shorten payloads and remove jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,0 @@
-#!/usr/bin/env groovy
-//Leave the above line alone.  It identifies this as a groovy script.
-@Library('vs-build-tools') _
-
-List<String> lvVersions = ['2020']
-
-diffPipeline(lvVersions[0])

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,9 +68,9 @@ stages:
         - controlFileName: 'control_custom_device'
           payloadMaps:
             - installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\Custom Devices\Communication Bus Template'
-              payloadLocation: 'Source\Built'
+              payloadLocation: ''
 
         - controlFileName: 'control_scripting'
           payloadMaps:
             - installLocation: 'ni-paths-LV$(lvVersion)DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\Communication Bus Template'
-              payloadLocation: 'Source\Built\Scripting'
+              payloadLocation: 'Scripting'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Now that we are using payloads from nirvana archives, we do not need to include the build output path.
Also remove the jenkinsfile

### Why should this Pull Request be merged?

If this is not included, we will not have any payloads in the builds

### What testing has been done?

PR Build output
