### PR TITLE
Add 2025, remove 2021. Bump version to 25.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ LabVIEW 2020
 
 ## Dependencies
 
-- [LabVIEW Real-Time Module 2020](https://www.ni.com/en-us/support/downloads/software-products/download.labview-real-time-module.html#345605)
+- [LabVIEW Real-Time Module 2023](https://www.ni.com/en-us/support/downloads/software-products/download.labview-real-time-module.html#345605)
 - [VeriStand Custom Device Development Tools](https://github.com/ni/niveristand-custom-device-development-tools)
   - Latest [released package](https://github.com/ni/niveristand-custom-device-development-tools/releases) supporting LabVIEW 2020
   - [HTML Workshop](https://github.com/ni/niveristand-custom-device-development-tools#external)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,11 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
-        - version: '2021'
-          bitness: '64bit'
         - version: '2023'
           bitness: '64bit'
         - version: '2024'
+          bitness: '64bit'
+        - version: '2025'
           bitness: '64bit'
 
       buildSteps:
@@ -60,7 +60,7 @@ stages:
           target: 'Linux x64'
           buildSpec: 'Engine Release'
 
-      releaseVersion: '24.0.0'
+      releaseVersion: '25.0.0'
       buildOutputLocation: 'Source\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\communication_bus_template'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Add lv2025. Remove lv2021. Bump release version to 25.0.0

### Why should this Pull Request be merged?

Code maintainance

### What testing has been done?

NA
