### PR TITLE
Drop lv23, Add lv 26 support, Bump to 26.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ The **VeriStand Communications Bus Template** provides a starting point for crea
 
 ## LabVIEW Version
 
-LabVIEW 2020
+LabVIEW 2024
 
 ## Dependencies
 
-- [LabVIEW Real-Time Module 2023](https://www.ni.com/en-us/support/downloads/software-products/download.labview-real-time-module.html#345605)
+- [LabVIEW Real-Time Module 2024](https://www.ni.com/en-us/support/downloads/software-products/download.labview-real-time-module.html#345605)
 - [VeriStand Custom Device Development Tools](https://github.com/ni/niveristand-custom-device-development-tools)
-  - Latest [released package](https://github.com/ni/niveristand-custom-device-development-tools/releases) supporting LabVIEW 2025
+  - Latest [released package](https://github.com/ni/niveristand-custom-device-development-tools/releases) supporting LabVIEW 2026
   - [HTML Workshop](https://github.com/ni/niveristand-custom-device-development-tools#external)
 - [NI VeriStand Custom Device Testing Tools](https://github.com/ni/niveristand-custom-device-testing-tools)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,11 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
-        - version: '2023'
-          bitness: '64bit'
         - version: '2024'
           bitness: '64bit'
         - version: '2025'
+          bitness: '64bit'
+        - version: '2026'
           bitness: '64bit'
 
       buildSteps:
@@ -60,7 +60,7 @@ stages:
           target: 'Linux x64'
           buildSpec: 'Engine Release'
 
-      releaseVersion: '25.0.0'
+      releaseVersion: '26.0.0'
       buildOutputLocation: 'Source\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\communication_bus_template'
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-wizard/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-wizard/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Dropped the support of LV 23
- Added the Suppport of LV 26
- Bumped the release version to 26.0.0
- Updated the readme.

### Why should this Pull Request be merged?

For Release

### What testing has been done?

PR Build
